### PR TITLE
Update pkgdown.yaml

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main, master]
   pull_request:
     branches: [main, master]
+    types:
+      - closed
   release:
     types: [published]
   workflow_dispatch:
@@ -13,6 +15,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:


### PR DESCRIPTION
Ensure pkgdown workflow only runs on release, push to main, or if the pull request to main is merged. Sick of it running on every gh pr create. See https://stackoverflow.com/questions/60710209/trigger-github-actions-only-when-pr-is-merged