### PR TITLE
Update pkgdown.yaml

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,11 +1,11 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
-  push:
-    branches: [main, master]
   pull_request:
     branches: [main, master]
+    types: [closed]
   release:
+    branches: [main]
     types: [published]
   workflow_dispatch:
 
@@ -13,7 +13,10 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    if: github.event.pull_request.merged == true
+    if: >-
+      github.event.pull_request.merged == true ||
+      github.event.release == true || 
+      github.event.workflow_dispatch == true
     runs-on: ubuntu-latest
     # Only restrict concurrency for non-PR jobs
     concurrency:
@@ -24,30 +27,23 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-
       - uses: r-lib/actions/setup-pandoc@v2
-
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
-          
       - run: sudo apt-get install -y libglpk40
-      
       - uses: r-lib/actions/setup-renv@v2
-
       - run: R CMD INSTALL .
-
-      # - uses: r-lib/actions/setup-r-dependencies@v2
-      #   with:
-      #     extra-packages: any::pkgdown, local::.
-      #     needs: website
 
       - name: Build site
         run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
         shell: Rscript {0}
 
       - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
+        if: >- 
+          github.event.pull_request.merged == true ||
+          github.event.release == true || 
+          github.event.workflow_dispatch == true
         uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           clean: true


### PR DESCRIPTION
#97 add events and conditions to workflow (job kept skipping on push because the pkgdown job had the condition that it would only run when the rent was pull_request.merged).
- removed workflow event trigger 'push'