### PR TITLE
Fix bug in `prpare_response_variables()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ManyEcoEvo
 Title: Meta-analyse data from 'Many-Analysts' style studies
-Version: 2.4.1.9000
+Version: 2.4.2
 Authors@R: c(
     person("Elliot", "Gould", , "elliot.gould@unimelb.edu.au", role = c("aut", "cre"),
            comment = c(ORCID = "https://orcid.org/0000-0002-6585-538X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# ManyEcoEvo (development version)
+# ManyEcoEvo 2.4.2
 
 # ManyEcoEvo 2.4.1
 

--- a/R/prepare_response_variables.R
+++ b/R/prepare_response_variables.R
@@ -13,6 +13,7 @@
 #' @import dplyr
 #' @import purrr
 #' @import rlang
+#' @importFrom pointblank expect_col_exists expect_col_is_numeric expect_col_is_character expect_col_vals_in_set
 prepare_response_variables <- function(ManyEcoEvo,
                                        estimate_type = character(1L),
                                        param_table = NULL,

--- a/R/prepare_response_variables.R
+++ b/R/prepare_response_variables.R
@@ -3,7 +3,7 @@
 #' @param ManyEcoEvo Complete ManyEcoEvo dataset containing nested datasets for each different analysis and exclusion set dataset
 #' @param estimate_type A character string of length 1, equal to either "Zr", "yi", "y25", "y50", "y75", indicating what type of estimates are being prepared.
 #' @param param_table A table of parameters \(mean, sd\) for *most* response variables used by analysts. This tibble is pulled from the named object exported by `ManyEcoEvo::`. but can be overwritten with the users's own `param_table` dataset.
-#' @param dataset_standardise A character string of length 1, equal to the name of the dataset to standardise the response variables to. If `NULL`, all datasets are standardised.
+#' @param dataset_standardise A character string of length 1, equal to the name of the dataset to standardise the response variables to. If `NULL` (default), no datasets are standardised.
 #' @return A tibble of nested list-columns
 #' @details Operates on nested list-columns of dataframes, where each dataframe contains the response variable data for a single analysis. The function standardises the response variable data for each analysis, and returns the modified dataset to the `data` list-column.
 #' @family targets-pipeline functions.
@@ -17,22 +17,43 @@ prepare_response_variables <- function(ManyEcoEvo,
                                        estimate_type = character(1L),
                                        param_table = NULL,
                                        dataset_standardise = NULL) {
-  match.arg(estimate_type, choices = c("Zr", "yi", "y25", "y50", "y75"), several.ok = FALSE)
+  match.arg(estimate_type, 
+            choices = c("Zr", "yi", "y25", "y50", "y75"), 
+            several.ok = FALSE)
   stopifnot(is.data.frame(ManyEcoEvo))
-  pointblank::expect_col_exists(object = ManyEcoEvo, columns = c(dataset, data))
+  pointblank::expect_col_exists(object = ManyEcoEvo, 
+                                columns = c(dataset, data))
   if (!is.null(dataset_standardise)) {
     stopifnot(is.character(dataset_standardise))
     stopifnot(length(dataset_standardise) >= 1)
     stopifnot(length(dataset_standardise) <= length(unique(ManyEcoEvo$dataset)))
-    match.arg(dataset_standardise, choices = ManyEcoEvo$dataset, several.ok = TRUE)
+    match.arg(dataset_standardise, 
+              choices = ManyEcoEvo$dataset,
+              several.ok = TRUE)
   }
+  if (!is.null(param_table)) {
+    stopifnot(is.data.frame(param_table))
+    pointblank::expect_col_exists(object = param_table, 
+                                  columns = c("variable", 
+                                              "parameter", 
+                                              "value"))
+    pointblank::expect_col_is_numeric(object = param_table, 
+                                      columns = "value")
+    pointblank::expect_col_is_character(object = param_table, 
+                                        columns = c("variable", 
+                                                    "parameter"))
+    pointblank::expect_col_vals_in_set(object = param_table, 
+                                       columns = "parameter", 
+                                       set = c("mean", "sd"))
+  }
+  
+  # ------ Function Body ------
   
   out <- ManyEcoEvo
   
   if (estimate_type != "Zr") {
-    if (is.null(param_table)) {
-      
-      cli::cli_abort("{.arg param_table} must be supplied for {.val {estimate_type}} data")
+    if (all(is.null(param_table), !is.null(dataset_standardise))) {
+      cli::cli_abort("{.arg param_table} must be supplied for {.val {estimate_type}} data when {.arg dataset_standardise} is not {.val NULL}.")
     }
     
     # ------ Back transform if estimate_type is yi only ------
@@ -70,17 +91,9 @@ prepare_response_variables <- function(ManyEcoEvo,
   if (is.null(dataset_standardise)) {
     out <- out %>%
       ungroup() %>%
-      dplyr::mutate(data = purrr::map2(
-        .x = data, 
-        .y = dataset,
-        .f = ~ standardise_response(
-          dat = .x,
-          estimate_type = !!{
-            estimate_type
-          },
-          param_table,
-          dataset = .y
-        )
+      dplyr::mutate(data = purrr::map(
+        data,
+        process_response
       ))
   } else {
     
@@ -89,7 +102,14 @@ prepare_response_variables <- function(ManyEcoEvo,
       fns = list(standardise_response)
     )
     
-    pmap_prepare_response <- function(data, estimate_type, param_table, dataset, fns, ...){
+    pmap_prepare_response <- function(data, 
+                                      estimate_type = character(1L), 
+                                      param_table, 
+                                      dataset = character(1L), 
+                                      fns, 
+                                      ...){ #TODO move into own function as internal
+      stopifnot(is.data.frame(data))
+      stopifnot(class(fns) == "function")
       fns(data, estimate_type, param_table, dataset)
     }
     

--- a/man/prepare_response_variables.Rd
+++ b/man/prepare_response_variables.Rd
@@ -18,7 +18,7 @@ prepare_response_variables(
 
 \item{param_table}{A table of parameters \(mean, sd\) for \emph{most} response variables used by analysts. This tibble is pulled from the named object exported by \verb{ManyEcoEvo::}. but can be overwritten with the users's own \code{param_table} dataset.}
 
-\item{dataset_standardise}{A character string of length 1, equal to the name of the dataset to standardise the response variables to. If \code{NULL}, all datasets are standardised.}
+\item{dataset_standardise}{A character string of length 1, equal to the name of the dataset to standardise the response variables to. If \code{NULL} (default), no datasets are standardised.}
 }
 \value{
 A tibble of nested list-columns


### PR DESCRIPTION
Fix bug in case when no standardisation of any datasets resulted in all datasets being standardised and update function documentaiton.

- **Update function `prepare_response_variables()`**
- **#102 devtools::document()**
- **#102 add importFrom for pointblank fns**
- **Increment version number to 2.4.2**
